### PR TITLE
Persistent group -jami

### DIFF
--- a/public/dummyGroupData.json
+++ b/public/dummyGroupData.json
@@ -1,5 +1,5 @@
 {
-    "count": 1,
+    "count": 2,
     "groups": [
         {
             "id": 1,

--- a/public/dummyGroupData.json
+++ b/public/dummyGroupData.json
@@ -12,6 +12,18 @@
             "kernelArgs": "",
             "kernelDevice": "",
             "hostcount": 1
+        },
+        {
+            "id": 2,
+            "name": "testgroup2",
+            "description": "",
+            "createdBy": "fog",
+            "createdTime": "2025-02-26 10:03:12",
+            "building": 0,
+            "kernel": "",
+            "kernelArgs": "",
+            "kernelDevice": "",
+            "hostcount": 1
         }
     ]
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -78,6 +78,22 @@ export default function Dashboard() {
     fetchData();
   }, []);
 
+  // Load selected group from local storage on component mount
+  useEffect(() => {
+    const storedGroupID = localStorage.getItem("selectedGroup");
+    if (storedGroupID) {
+      const foundGroup = groups.find((g: any) => g.id === Number(storedGroupID));
+      if (foundGroup) setSelectedGroup(foundGroup);
+    }
+  }, [groups]);
+
+  // Save selected group to local storage whenever it changes
+  useEffect(() => {
+    if (selectedGroup) {
+      localStorage.setItem("selectedGroup", String(selectedGroup.id));
+    }
+  }, [selectedGroup]);
+
   if (loading) {
     return <Typography>Loading...</Typography>;
   }
@@ -338,15 +354,19 @@ export default function Dashboard() {
                   labelId="group-select-label"
                   value={selectedGroup?.id ?? ""}
                   onChange={(e) => {
-                    const group = groups.find((g) => g.id === Number(e.target.value));
+                    const chosenValue = e.target.value;
+                    if (chosenValue === "") {
+                      setSelectedGroup(null);
+                      return;
+                    }
+                    const group = groups.find((g) => g.id === Number(chosenValue));
                     setSelectedGroup(group ?? null);
                   }}
                   label="Group"
-                  size="medium"
                   sx={{ background: "#fff", borderRadius: 1 }}
                 >
                   {groups.map((group: any) => (
-                    <MenuItem key={group.id} value={group.id}>
+                    <MenuItem key={group.id} value={String(group.id)}>
                       {group.name}
                     </MenuItem>
                   ))}
@@ -366,7 +386,7 @@ export default function Dashboard() {
               }}
             >
               <CardContent>
-                <Typography variant="h6" sx={{ fontSize: "1.1rem" }}>
+                <Typography variant="h6" sx={{ fontSize: "1.1rem", color: "#1976d2", mb: 1 }}>
                   Hosts Assigned to '{selectedGroup.name}'
                 </Typography>
                 <Typography variant="subtitle1" sx={{ mb: 1, fontSize: "0.95rem" }}>

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -98,6 +98,7 @@ const MenuBar = ({ session }: MenuBarProps) => {
                         "Are you sure you want to log out from FOG GUI?"
                       );
                       if (confirmed) {
+                        localStorage.removeItem("selectedGroup")
                         signOut({ callbackUrl: "/" });
                       }
                     }}


### PR DESCRIPTION
- Added logic to save the selected group to localStorage in the Dashboard component (src/app/dashboard/page.tsx).

- Group selection is restored on component mount, ensuring users return to their previously selected group.

- In MenuBar (src/components/MenuBar.tsx), clearing the selected group from localStorage upon user logout to ensure a clean session start.

